### PR TITLE
Use --compilers option in test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,11 @@
 ```json
 {
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --compilers js:6to5/register"
   },
   "dependencies": {
     "6to5": "*",
     "mocha": "*"
   }
 }
-```
-
-**test/mocha.opts**
-
-```
---require 6to5/register
 ```


### PR DESCRIPTION
Removes the mocha.opt file and uses the --compilers option instead of --require